### PR TITLE
RCLL-458 ensure when user has NOMIS made recalls that the overview page displays and does not break

### DIFF
--- a/server/services/remandAndSentencingService.ts
+++ b/server/services/remandAndSentencingService.ts
@@ -37,6 +37,7 @@ export default class RemandAndSentencingService {
     try {
       parsedRecall = recallDate instanceof Date ? recallDate : parse(recallDate, 'yyyy-MM-dd', new Date())
     } catch (err) {
+      // eslint-disable-next-line no-console
       console.error('Error parsing recallDate:', recallDate, err)
       return 0
     }


### PR DESCRIPTION
BUG FIX: when a user has 1 or more recalls made from nomis, it would say `something went wrong...` and not display the overview page. 
Now it does show the page