### PR TITLE
CRS-2751: Fix recall location null issue

### DIFF
--- a/server/routes/prisoner/handlers/overview.test.ts
+++ b/server/routes/prisoner/handlers/overview.test.ts
@@ -979,7 +979,55 @@ describe('Route Handlers - Overview', () => {
 
       const $ = cheerio.load(res.text)
 
+      expect($('[data-qa=recall-card-title]').text().trim()).toBe('Recorded on 01 January 2024 at Leeds')
+    })
+
+    it('Should load location name from prison register when location is set and show in recall card title', async () => {
+      prisonerSearchService.getByPrisonerNumber.mockResolvedValue({
+        prisonerNumber: 'A12345B',
+        prisonId: 'MDI',
+      } as Prisoner)
+      adjustmentsService.getAdjustments.mockResolvedValue([])
+      prisonerService.getServiceDefinitions.mockResolvedValue(serviceDefinitionsNoThingsToDo)
+      remandAndSentencingService.getMostRecentRecall.mockResolvedValue({
+        source: 'DPS',
+        createdAt: '2024-01-01',
+        recallType: RecallTypes.STANDARD_RECALL,
+        location: 'LDS',
+        revocationDate: '2024-01-05',
+        returnToCustodyDate: new Date('2024-01-10'),
+      } as Recall)
+      prisonService.getPrisonName.mockResolvedValue('Leeds')
+
+      const res = await request(app).get('/prisoner/A12345B/overview').expect(200).expect('Content-Type', /html/)
+
+      const $ = cheerio.load(res.text)
+
+      expect($('[data-qa=recall-card-title]').text().trim()).toBe('Recorded on 01 January 2024 at Leeds')
+    })
+
+    it('Should not load location name from prison register when location is not set and omit from the recall card title', async () => {
+      prisonerSearchService.getByPrisonerNumber.mockResolvedValue({
+        prisonerNumber: 'A12345B',
+        prisonId: 'MDI',
+      } as Prisoner)
+      adjustmentsService.getAdjustments.mockResolvedValue([])
+      prisonerService.getServiceDefinitions.mockResolvedValue(serviceDefinitionsNoThingsToDo)
+      remandAndSentencingService.getMostRecentRecall.mockResolvedValue({
+        source: 'DPS',
+        createdAt: '2024-01-01',
+        recallType: RecallTypes.STANDARD_RECALL,
+        location: null,
+        revocationDate: '2024-01-05',
+        returnToCustodyDate: new Date('2024-01-10'),
+      } as Recall)
+
+      const res = await request(app).get('/prisoner/A12345B/overview').expect(200).expect('Content-Type', /html/)
+
+      const $ = cheerio.load(res.text)
+
       expect($('[data-qa=recall-card-title]').text().trim()).toBe('Recorded on 01 January 2024')
+      expect(prisonService.getPrisonName).not.toHaveBeenCalled()
     })
 
     it('should not show view all recalls link when user does not have access to recalls', async () => {

--- a/server/routes/prisoner/handlers/overview.ts
+++ b/server/routes/prisoner/handlers/overview.ts
@@ -6,7 +6,7 @@ import CalculateReleaseDatesService from '../../../services/calculateReleaseDate
 import { Prisoner } from '../../../@types/prisonerSearchApi/types'
 import RemandAndSentencingService from '../../../services/remandAndSentencingService'
 import PrisonService from '../../../services/prisonService'
-import { ImmigrationDetention } from '../../../@types/remandAndSentencingApi/remandAndSentencingTypes'
+import { ImmigrationDetention, Recall } from '../../../@types/remandAndSentencingApi/remandAndSentencingTypes'
 import config from '../../../config'
 
 export default class OverviewRoutes {
@@ -54,12 +54,12 @@ export default class OverviewRoutes {
         : false
 
     const anyThingsToDo = Object.values(serviceDefinitions.services).some(it => it.thingsToDo.count > 0)
-    const latestRecall = hasRasAccess
+    const latestRecall: Recall & { locationName?: string } = hasRasAccess
       ? await this.remandAndSentencingService.getMostRecentRecall(prisoner.prisonerNumber, token)
       : null
 
-    if (latestRecall) {
-      latestRecall.location = await this.prisonService.getPrisonName(latestRecall.location, username)
+    if (latestRecall && latestRecall.location) {
+      latestRecall.locationName = await this.prisonService.getPrisonName(latestRecall.location, username)
     }
 
     const latestImmigrationRecord = hasImmigrationDetentionAccess
@@ -96,7 +96,7 @@ export default class OverviewRoutes {
   }
 
   private getImmigrationDetentionMessage(latestRecord: ImmigrationDetention) {
-    let message = ''
+    let message: string
     if (latestRecord) {
       const formattedRecordDate = dayjs(latestRecord.recordDate).format('D MMMM YYYY')
       const recordedStr = `dated ${formattedRecordDate}`


### PR DESCRIPTION
Prison Register API no longer accepts null in the array list. If it's null we shouldn't bother calling looking up the location anyway.

Also it turned out that the location name was never being displayed properly as we were setting `location` but the template referenced `locationName`.