### PR TITLE
- remove legacy .document.new css class

### DIFF
--- a/assets/scss/components/_prisoner-documents.scss
+++ b/assets/scss/components/_prisoner-documents.scss
@@ -37,7 +37,7 @@
 }
 
 .document__row {
-  margin-bottom: govuk-spacing(1);
+  margin-bottom: 0;
 }
 
 .document__row:last-child {

--- a/assets/scss/overrides/_local.scss
+++ b/assets/scss/overrides/_local.scss
@@ -1,11 +1,4 @@
 .govuk-main-wrapper {
   min-height: 600px;
-  padding-top: 0px;
-}
-
-.document {
-  &.new {
-    border-left: 6px solid govuk-colour("blue");
-    padding-left: 6px;
-  }
+  padding-top: 0;
 }


### PR DESCRIPTION
- set margin to 0 (  the .document__header carries margin-bottom: govuk-spacing(2) (10px) and each value paragraph carries govuk-!-margin-bottom-2 (10px), so leaving the row margin at 0 makes the header to row gap and the row to row gap both land on 10px.
- removed px (0 is enough)