### PR TITLE
Single line display of document 

### DIFF
--- a/assets/scss/components/_prisoner-documents.scss
+++ b/assets/scss/components/_prisoner-documents.scss
@@ -46,4 +46,5 @@
 
 .document__meta {
   color: govuk-colour("dark-grey");
+  font-size: 0.875rem;
 }

--- a/server/views/pages/prisoner/documents.njk
+++ b/server/views/pages/prisoner/documents.njk
@@ -60,7 +60,8 @@
                                     {{ document.typeDescription }}
                                     <span class="govuk-visually-hidden">(opens in new tab)</span>
                                 </a>
-                                <span class="document__meta govuk-!-margin-bottom-0  govuk-!-margin-left-2" data-qa="document-file-meta">
+                                <span class="document__meta govuk-!-margin-bottom-0  govuk-!-margin-left-2"
+                                      data-qa="document-file-meta">
                                     {{ document.fileExtension | uppercase }} {{ document.fileSize | humanReadableFileSize }}
                                 </span>
                             </p>

--- a/server/views/pages/prisoner/documents.njk
+++ b/server/views/pages/prisoner/documents.njk
@@ -60,9 +60,9 @@
                                     {{ document.typeDescription }}
                                     <span class="govuk-visually-hidden">(opens in new tab)</span>
                                 </a>
-                            </p>
-                            <p class="govuk-body-s document__meta govuk-!-margin-bottom-0" data-qa="document-file-meta">
-                                {{ document.fileExtension | uppercase }} {{ document.fileSize | humanReadableFileSize }}
+                                <span class="document__meta govuk-!-margin-bottom-0  govuk-!-margin-left-2" data-qa="document-file-meta">
+                                    {{ document.fileExtension | uppercase }} {{ document.fileSize | humanReadableFileSize }}
+                                </span>
                             </p>
                         </div>
 


### PR DESCRIPTION
- match style of document__meta to govuk-body-s
- move metadata display into inline within header P