### PR TITLE
Show meaningful filename in inline document viewer

### DIFF
--- a/server/routes/prisoner/index.ts
+++ b/server/routes/prisoner/index.ts
@@ -49,7 +49,7 @@ export default function Index({
     ).documents,
   )
   get(
-    '/:prisonerNumber/documents/:documentId/download',
+    ['/:prisonerNumber/documents/:documentId/download/:filename', '/:prisonerNumber/documents/:documentId/download'],
     new DocumentRoutes(
       prisonerService,
       documentManagementService,

--- a/server/routes/unmatchedDocument/index.ts
+++ b/server/routes/unmatchedDocument/index.ts
@@ -8,7 +8,10 @@ export default function Index(documentManagementService: DocumentManagementServi
   const get = (path: string | string[], handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
 
   get('/', new UnmatchedDocumentRoutes(documentManagementService).documents)
-  get('/:documentId/download', new UnmatchedDocumentRoutes(documentManagementService).download)
+  get(
+    ['/:documentId/download/:filename', '/:documentId/download'],
+    new UnmatchedDocumentRoutes(documentManagementService).download,
+  )
 
   return router
 }

--- a/server/views/pages/prisoner/documents.njk
+++ b/server/views/pages/prisoner/documents.njk
@@ -56,7 +56,7 @@
                                 <a class="govuk-link govuk-link--no-visited-state prisoner-doc-link"
                                    target="_blank"
                                    rel="noreferrer noopener"
-                                   href="/prisoner/{{ prisoner.prisonerNumber }}/documents/{{ document.documentUuid }}/download">
+                                   href="/prisoner/{{ prisoner.prisonerNumber }}/documents/{{ document.documentUuid }}/download/{{ (document.filename + '.' + document.fileExtension) | urlencode }}">
                                     {{ document.typeDescription }}
                                     <span class="govuk-visually-hidden">(opens in new tab)</span>
                                 </a>

--- a/server/views/pages/unmatchedDocuments/index.njk
+++ b/server/views/pages/unmatchedDocuments/index.njk
@@ -20,7 +20,7 @@
       <div class="govuk-grid-column-two-thirds">
         Sort by: <a class="govuk-link govuk-link--no-visited-state govuk-!-margin-right-1" href="/unmatched-documents?sortBy=MOST_RECENT">Most recent</a>
         <span class="govuk-hint govuk-!-margin-right-1">|</span>
-        <a class="govuk-link govuk-link--no-visited-state" href="/unmatched-documents?sortBy=EARLIEST">Earliest<a>
+        <a class="govuk-link govuk-link--no-visited-state" href="/unmatched-documents?sortBy=EARLIEST">Earliest</a>
       </div>           
       <div class="govuk-grid-column-one-third">
         <div class="gouk-body">Showing {% if paginationResults.count %}<strong>{{ paginationResults.from }}</strong> to <strong>{{ paginationResults.to }}</strong>{% else %}<strong>0</strong>{% endif %} of <strong>{{ totalResults }}</strong> documents</div>
@@ -34,7 +34,7 @@
               <p class="govuk-body govuk-!-margin-bottom-1">
                   <a class="govuk-link govuk-link--no-visited-state prisoner-doc-link"
                       target="_blank"
-                      href="/unmatched-documents/{{document.documentUuid}}/download">{{document.typeDescription}}</a>
+                      href="/unmatched-documents/{{document.documentUuid}}/download/{{ (document.filename + '.' + document.fileExtension) | urlencode }}">{{document.typeDescription}}</a>
                     {{document.fileExtension | uppercase}} {{document.fileSize | humanReadableFileSize}}
               </p>
           </div>


### PR DESCRIPTION
Document links open inline in a new tab, but the PDF viewer takes its title from the last URL segment, which was "download". The Content-Disposition filename only governs the save-as name, not the inline title.

Append the filename as a trailing URL segment on both the prisoner and unmatched document download links, and accept an optional :filename segment on both routes (kept optional so existing URLs still resolve). The segment is cosmetic; handlers still key off documentId for lookup and auth.

Also fix missing close </a> tag