### PR TITLE
RASS-2451 - Adjusting readonly-overview permissions

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -13,6 +13,7 @@ generic-service:
     MANAGE_USERS_API_URL: "https://manage-users-api-dev.hmpps.service.justice.gov.uk"
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api-dev.prison.service.justice.gov.uk"
     COMPONENT_API_URL: "https://frontend-components-dev.hmpps.service.justice.gov.uk"
+    AUTH_PATH_EXCLUSIONS_ENABLED: true
     COMMON_COMPONENTS_ENABLED: true
     IMMIGRATION_DETENTION_ENABLED: true
     IMMIGRATION_DETENTION_URL: "https://immigration-detention-dev.hmpps.service.justice.gov.uk"

--- a/server/app.ts
+++ b/server/app.ts
@@ -30,6 +30,10 @@ export default function createApp(services: Services): express.Application {
   app.set('trust proxy', true)
   app.set('port', process.env.PORT || 3000)
 
+  function getAuthPathExclusions() {
+    return ['^/prisoner/[^/]+/readonly-overview$']
+  }
+
   app.use(metricsMiddleware)
   app.use(setUpHealthChecks(services.applicationInfo))
   app.use(setUpWebSecurity())
@@ -38,7 +42,12 @@ export default function createApp(services: Services): express.Application {
   app.use(setUpStaticResources())
   nunjucksSetup(app, services.applicationInfo)
   app.use(setUpAuthentication())
-  app.use(authorisationMiddleware(['ROLE_RELEASE_DATES_CALCULATOR']))
+  app.use(
+    authorisationMiddleware(
+      ['ROLE_RELEASE_DATES_CALCULATOR'],
+      config.apis.hmppsAuth.authPathExclusionsEnabled ? getAuthPathExclusions() : [],
+    ),
+  )
   app.use(setUpCsrf())
   app.use(setUpCurrentUser(services))
 

--- a/server/config.ts
+++ b/server/config.ts
@@ -72,6 +72,7 @@ export default {
       apiClientSecret: get('API_CLIENT_SECRET', 'clientsecret', requiredInProduction),
       systemClientId: get('SYSTEM_CLIENT_ID', 'clientid', requiredInProduction),
       systemClientSecret: get('SYSTEM_CLIENT_SECRET', 'clientsecret', requiredInProduction),
+      authPathExclusionsEnabled: get('AUTH_PATH_EXCLUSIONS_ENABLED', 'false') === 'true',
     },
     manageUsersApi: {
       url: get('MANAGE_USERS_API_URL', 'http://localhost:9091', requiredInProduction),

--- a/server/middleware/authorisationMiddleware.test.ts
+++ b/server/middleware/authorisationMiddleware.test.ts
@@ -53,6 +53,36 @@ describe('authorisationMiddleware', () => {
     expect(res.redirect).toHaveBeenCalledWith('/authError')
   })
 
+  it('should return next when user has no authorised roles but accesses excluded path', () => {
+    const res = createResWithToken({ authorities: [] })
+
+    const reqWithPath = { path: '/prisoner/ABC123/readonly-overview' } as Request
+    authorisationMiddleware(['NON_RELEVANT_ROLE'], ['^/prisoner/[^/]+/readonly-overview$'])(reqWithPath, res, next)
+
+    expect(next).toHaveBeenCalled()
+    expect(res.redirect).not.toHaveBeenCalled()
+  })
+
+  it('should redirect when user has no authorised roles and accesses a non excluded path', () => {
+    const res = createResWithToken({ authorities: [] })
+
+    const reqWithPath = { path: '/prisoner/ABC123/overview' } as Request
+    authorisationMiddleware(['NON_RELEVANT_ROLE'], ['^/prisoner/[^/]+/readonly-overview$'])(reqWithPath, res, next)
+
+    expect(next).not.toHaveBeenCalled()
+    expect(res.redirect).toHaveBeenCalledWith('/authError')
+  })
+
+  it('should redirect when user has no authorised roles and accesses a path with no exclusions specified', () => {
+    const res = createResWithToken({ authorities: [] })
+
+    const reqWithPath = { path: '/' } as Request
+    authorisationMiddleware(['NON_RELEVANT_ROLE'], [])(reqWithPath, res, next)
+
+    expect(next).not.toHaveBeenCalled()
+    expect(res.redirect).toHaveBeenCalledWith('/authError')
+  })
+
   it('should return next when user has authorised role', () => {
     const res = createResWithToken({ authorities: ['ROLE_SOME_REQUIRED_ROLE'] })
 

--- a/server/middleware/authorisationMiddleware.ts
+++ b/server/middleware/authorisationMiddleware.ts
@@ -4,8 +4,18 @@ import type { RequestHandler } from 'express'
 import logger from '../../logger'
 import asyncMiddleware from './asyncMiddleware'
 
-export default function authorisationMiddleware(authorisedRoles: string[] = []): RequestHandler {
+export default function authorisationMiddleware(
+  authorisedRoles: string[] = [],
+  excludedPaths: string[] = [],
+): RequestHandler {
+  const excludedPathRegExps = excludedPaths.map(p => new RegExp(p))
+
   return asyncMiddleware((req, res, next) => {
+    // Skip authorisation for excluded paths
+    if (excludedPathRegExps.some(pattern => pattern.test(req.path))) {
+      return next()
+    }
+
     // authorities in the user token will always be prefixed by ROLE_.
     // Convert roles that are passed into this function without the prefix so that we match correctly.
     const authorisedAuthorities = authorisedRoles.map(role => (role.startsWith('ROLE_') ? role : `ROLE_${role}`))

--- a/server/routes/prisoner/handlers/overview.test.ts
+++ b/server/routes/prisoner/handlers/overview.test.ts
@@ -32,7 +32,7 @@ jest.mock('../../../services/remandAndSentencingService')
 const prisonerService = new PrisonerService(null) as jest.Mocked<PrisonerService>
 const prisonerSearchService = new PrisonerSearchService(null) as jest.Mocked<PrisonerSearchService>
 const adjustmentsService = new AdjustmentsService(null) as jest.Mocked<AdjustmentsService>
-const calculateReleaseDatesService = new CalculateReleaseDatesService() as jest.Mocked<CalculateReleaseDatesService>
+const calculateReleaseDatesService = new CalculateReleaseDatesService(null) as jest.Mocked<CalculateReleaseDatesService>
 const remandAndSentencingService = new RemandAndSentencingService(null) as jest.Mocked<RemandAndSentencingService>
 const prisonService = new PrisonService(null) as jest.Mocked<PrisonService>
 const immigrationDetentionService = new ImmigrationDetentionService() as jest.Mocked<ImmigrationDetentionService>

--- a/server/routes/prisoner/handlers/readonlyOverview.test.ts
+++ b/server/routes/prisoner/handlers/readonlyOverview.test.ts
@@ -34,7 +34,7 @@ jest.mock('../../../services/ImmigrationDetentionService')
 
 const prisonerService = new PrisonerService(null) as jest.Mocked<PrisonerService>
 const prisonerSearchService = new PrisonerSearchService(null) as jest.Mocked<PrisonerSearchService>
-const calculateReleaseDatesService = new CalculateReleaseDatesService() as jest.Mocked<CalculateReleaseDatesService>
+const calculateReleaseDatesService = new CalculateReleaseDatesService(null) as jest.Mocked<CalculateReleaseDatesService>
 const remandAndSentencingService = new RemandAndSentencingService(null) as jest.Mocked<RemandAndSentencingService>
 const prisonService = new PrisonService(null) as jest.Mocked<PrisonService>
 const courtRegisterService = new CourtRegisterService(null) as jest.Mocked<CourtRegisterService>
@@ -190,8 +190,8 @@ describe('Route Handlers - Readonly Overview', () => {
         prisonId: 'MDI',
       } as Prisoner)
       prisonerService.getStartOfSentenceEnvelope.mockResolvedValue(new Date())
-      prisonerService.getNextCourtEvent.mockResolvedValue({} as CourtEventDetails)
-      prisonerService.hasActiveSentences.mockResolvedValue(false)
+      prisonerService.getNextCourtEventAsSystem.mockResolvedValue({} as CourtEventDetails)
+      prisonerService.hasActiveSentencesAsSystem.mockResolvedValue(false)
       prisonerService.getServiceDefinitions.mockResolvedValue(serviceDefinitionsNoThingsToDo)
 
       return request(app)
@@ -207,8 +207,8 @@ describe('Route Handlers - Readonly Overview', () => {
         prisonerNumber: 'A12345B',
         prisonId: 'MDI',
       } as Prisoner)
-      prisonerService.getNextCourtEvent.mockResolvedValue({} as CourtEventDetails)
-      prisonerService.hasActiveSentences.mockResolvedValue(false)
+      prisonerService.getNextCourtEventAsSystem.mockResolvedValue({} as CourtEventDetails)
+      prisonerService.hasActiveSentencesAsSystem.mockResolvedValue(false)
       prisonerService.getServiceDefinitions.mockResolvedValue(serviceDefinitionsNoThingsToDo)
 
       return request(app)
@@ -223,8 +223,8 @@ describe('Route Handlers - Readonly Overview', () => {
         prisonerNumber: 'A12345B',
         prisonId: 'MDI',
       } as Prisoner)
-      prisonerService.getNextCourtEvent.mockResolvedValue({} as CourtEventDetails)
-      prisonerService.hasActiveSentences.mockResolvedValue(false)
+      prisonerService.getNextCourtEventAsSystem.mockResolvedValue({} as CourtEventDetails)
+      prisonerService.hasActiveSentencesAsSystem.mockResolvedValue(false)
       prisonerService.getServiceDefinitions.mockResolvedValue(serviceDefinitionsNoThingsToDo)
 
       return request(app)
@@ -244,8 +244,8 @@ describe('Route Handlers - Readonly Overview', () => {
         prisonerNumber: 'A12345B',
         prisonId: 'MDI',
       } as Prisoner)
-      prisonerService.getNextCourtEvent.mockResolvedValue({} as CourtEventDetails)
-      prisonerService.hasActiveSentences.mockResolvedValue(false)
+      prisonerService.getNextCourtEventAsSystem.mockResolvedValue({} as CourtEventDetails)
+      prisonerService.hasActiveSentencesAsSystem.mockResolvedValue(false)
       prisonerService.getServiceDefinitions.mockResolvedValue(serviceDefinitionsNoThingsToDo)
 
       return request(app)
@@ -282,10 +282,12 @@ describe('Route Handlers - Readonly Overview', () => {
         prisonerNumber: 'A12345B',
         prisonId: 'MDI',
       } as Prisoner)
-      prisonerService.getNextCourtEvent.mockResolvedValue({} as CourtEventDetails)
-      prisonerService.hasActiveSentences.mockResolvedValue(true)
+      prisonerService.getNextCourtEventAsSystem.mockResolvedValue({} as CourtEventDetails)
+      prisonerService.hasActiveSentencesAsSystem.mockResolvedValue(true)
       prisonerService.getServiceDefinitions.mockResolvedValue(serviceDefinitionsNoThingsToDo)
-      calculateReleaseDatesService.getLatestCalculationForPrisoner.mockResolvedValue(latestCalculationWithMultipleDates)
+      calculateReleaseDatesService.getLatestCalculationForPrisonerAsSystem.mockResolvedValue(
+        latestCalculationWithMultipleDates,
+      )
 
       const res = await request(app).get('/prisoner/A12345B/readonly-overview').expect(200)
 
@@ -300,11 +302,11 @@ describe('Route Handlers - Readonly Overview', () => {
         prisonerNumber: 'A12345B',
         prisonId: 'MDI',
       } as Prisoner)
-      prisonerService.getNextCourtEvent.mockResolvedValue({} as CourtEventDetails)
-      prisonerService.hasActiveSentences.mockResolvedValue(true)
+      prisonerService.getNextCourtEventAsSystem.mockResolvedValue({} as CourtEventDetails)
+      prisonerService.hasActiveSentencesAsSystem.mockResolvedValue(true)
       prisonerService.getServiceDefinitions.mockResolvedValue(serviceDefinitionsNoThingsToDo)
       // fixture 'latestCalculation' only contains a CRD
-      calculateReleaseDatesService.getLatestCalculationForPrisoner.mockResolvedValue(latestCalculation)
+      calculateReleaseDatesService.getLatestCalculationForPrisonerAsSystem.mockResolvedValue(latestCalculation)
 
       const res = await request(app).get('/prisoner/A12345B/readonly-overview').expect(200)
 
@@ -318,10 +320,10 @@ describe('Route Handlers - Readonly Overview', () => {
         prisonerNumber: 'A12345B',
         prisonId: 'MDI',
       } as Prisoner)
-      prisonerService.getNextCourtEvent.mockResolvedValue({} as CourtEventDetails)
-      prisonerService.hasActiveSentences.mockResolvedValue(true)
+      prisonerService.getNextCourtEventAsSystem.mockResolvedValue({} as CourtEventDetails)
+      prisonerService.hasActiveSentencesAsSystem.mockResolvedValue(true)
       prisonerService.getServiceDefinitions.mockResolvedValue(serviceDefinitionsNoThingsToDo)
-      calculateReleaseDatesService.getLatestCalculationForPrisoner.mockResolvedValue(latestCalculation)
+      calculateReleaseDatesService.getLatestCalculationForPrisonerAsSystem.mockResolvedValue(latestCalculation)
 
       return request(app)
         .get('/prisoner/A12345B/readonly-overview')
@@ -341,7 +343,7 @@ describe('Route Handlers - Readonly Overview', () => {
         prisonerNumber: 'A12345B',
         prisonId: 'MDI',
       } as Prisoner)
-      prisonerService.hasActiveSentences.mockResolvedValue(false)
+      prisonerService.hasActiveSentencesAsSystem.mockResolvedValue(false)
 
       const res = await request(app).get('/prisoner/A12345B/readonly-overview').expect(200)
 
@@ -353,25 +355,25 @@ describe('Route Handlers - Readonly Overview', () => {
         prisonerNumber: 'A12345B',
         prisonId: 'MDI',
       } as Prisoner)
-      prisonerService.hasActiveSentences.mockResolvedValue(false)
+      prisonerService.hasActiveSentencesAsSystem.mockResolvedValue(false)
 
       await request(app).get('/prisoner/A12345B/readonly-overview').expect(200)
 
-      expect(calculateReleaseDatesService.getLatestCalculationForPrisoner).not.toHaveBeenCalled()
+      expect(calculateReleaseDatesService.getLatestCalculationForPrisonerAsSystem).not.toHaveBeenCalled()
     })
     it('should fetch the latest calculation when there are active sentences', async () => {
       prisonerSearchService.getByPrisonerNumber.mockResolvedValue({
         prisonerNumber: 'A12345B',
         prisonId: 'MDI',
       } as Prisoner)
-      prisonerService.hasActiveSentences.mockResolvedValue(true)
-      calculateReleaseDatesService.getLatestCalculationForPrisoner.mockResolvedValue(latestCalculation)
+      prisonerService.hasActiveSentencesAsSystem.mockResolvedValue(true)
+      calculateReleaseDatesService.getLatestCalculationForPrisonerAsSystem.mockResolvedValue(latestCalculation)
 
       await request(app).get('/prisoner/A12345B/readonly-overview').expect(200)
 
-      expect(calculateReleaseDatesService.getLatestCalculationForPrisoner).toHaveBeenCalledWith(
+      expect(calculateReleaseDatesService.getLatestCalculationForPrisonerAsSystem).toHaveBeenCalledWith(
         'A12345B',
-        defaultUser.token,
+        defaultUser.username,
       )
     })
 
@@ -380,10 +382,10 @@ describe('Route Handlers - Readonly Overview', () => {
         prisonerNumber: 'A12345B',
         prisonId: 'MDI',
       } as Prisoner)
-      prisonerService.getNextCourtEvent.mockResolvedValue({} as CourtEventDetails)
-      prisonerService.hasActiveSentences.mockResolvedValue(true)
+      prisonerService.getNextCourtEventAsSystem.mockResolvedValue({} as CourtEventDetails)
+      prisonerService.hasActiveSentencesAsSystem.mockResolvedValue(true)
       prisonerService.getServiceDefinitions.mockResolvedValue(serviceDefinitionsNoThingsToDo)
-      calculateReleaseDatesService.getLatestCalculationForPrisoner.mockResolvedValue(latestCalculation)
+      calculateReleaseDatesService.getLatestCalculationForPrisonerAsSystem.mockResolvedValue(latestCalculation)
 
       const res = await request(app).get('/prisoner/A12345B/readonly-overview').expect(200)
 
@@ -398,7 +400,7 @@ describe('Route Handlers - Readonly Overview', () => {
         prisonerNumber: 'A12345B',
         prisonId: 'MDI',
       } as Prisoner)
-      prisonerService.hasActiveSentences.mockResolvedValue(false)
+      prisonerService.hasActiveSentencesAsSystem.mockResolvedValue(false)
       remandAndSentencingService.searchCourtCases.mockResolvedValue({
         content: [
           {
@@ -427,7 +429,7 @@ describe('Route Handlers - Readonly Overview', () => {
         prisonerNumber: 'A12345B',
         prisonId: 'MDI',
       } as Prisoner)
-      prisonerService.hasActiveSentences.mockResolvedValue(false)
+      prisonerService.hasActiveSentencesAsSystem.mockResolvedValue(false)
       remandAndSentencingService.searchCourtCases.mockResolvedValue({
         content: [
           {
@@ -456,7 +458,7 @@ describe('Route Handlers - Readonly Overview', () => {
         prisonerNumber: 'A12345B',
         prisonId: 'MDI',
       } as Prisoner)
-      prisonerService.hasActiveSentences.mockResolvedValue(false)
+      prisonerService.hasActiveSentencesAsSystem.mockResolvedValue(false)
 
       // default fixture court case is ACTIVE
       const res = await request(app).get('/prisoner/A12345B/readonly-overview').expect(200)
@@ -470,7 +472,7 @@ describe('Route Handlers - Readonly Overview', () => {
         prisonerNumber: 'A12345B',
         prisonId: 'MDI',
       } as Prisoner)
-      prisonerService.hasActiveSentences.mockResolvedValue(false)
+      prisonerService.hasActiveSentencesAsSystem.mockResolvedValue(false)
 
       await request(app).get('/prisoner/A12345B/readonly-overview?pageNumber=2').expect(200)
 
@@ -488,7 +490,7 @@ describe('Route Handlers - Readonly Overview', () => {
         prisonerNumber: 'A12345B',
         prisonId: 'MDI',
       } as Prisoner)
-      prisonerService.hasActiveSentences.mockResolvedValue(false)
+      prisonerService.hasActiveSentencesAsSystem.mockResolvedValue(false)
 
       await request(app).get('/prisoner/A12345B/readonly-overview').expect(200)
 
@@ -506,7 +508,7 @@ describe('Route Handlers - Readonly Overview', () => {
         prisonerNumber: 'A12345B',
         prisonId: 'MDI',
       } as Prisoner)
-      prisonerService.hasActiveSentences.mockResolvedValue(false)
+      prisonerService.hasActiveSentencesAsSystem.mockResolvedValue(false)
 
       await request(app).get('/prisoner/A12345B/readonly-overview').expect(200)
 
@@ -522,7 +524,7 @@ describe('Route Handlers - Readonly Overview', () => {
         prisonerNumber: 'A12345B',
         prisonId: 'MDI',
       } as Prisoner)
-      prisonerService.hasActiveSentences.mockResolvedValue(false)
+      prisonerService.hasActiveSentencesAsSystem.mockResolvedValue(false)
 
       await request(app).get('/prisoner/A12345B/readonly-overview').expect(200)
 
@@ -537,7 +539,7 @@ describe('Route Handlers - Readonly Overview', () => {
         prisonerNumber: 'A12345B',
         prisonId: 'MDI',
       } as Prisoner)
-      prisonerService.hasActiveSentences.mockResolvedValue(false)
+      prisonerService.hasActiveSentencesAsSystem.mockResolvedValue(false)
 
       const res = await request(app).get('/prisoner/A12345B/readonly-overview').expect(200)
 
@@ -550,7 +552,7 @@ describe('Route Handlers - Readonly Overview', () => {
         prisonerNumber: 'A12345B',
         prisonId: 'MDI',
       } as Prisoner)
-      prisonerService.hasActiveSentences.mockResolvedValue(false)
+      prisonerService.hasActiveSentencesAsSystem.mockResolvedValue(false)
 
       const res = await request(app).get('/prisoner/A12345B/readonly-overview').expect(200)
 
@@ -577,7 +579,7 @@ describe('Route Handlers - Readonly Overview', () => {
         prisonerNumber: 'A12345B',
         prisonId: 'MDI',
       } as Prisoner)
-      prisonerService.hasActiveSentences.mockResolvedValue(false)
+      prisonerService.hasActiveSentencesAsSystem.mockResolvedValue(false)
       remandAndSentencingService.searchCourtCases.mockResolvedValue({ content: [] } as SearchCourtCasesPage)
       remandAndSentencingService.getConsecutiveToDetails.mockResolvedValue({
         sentences: [],
@@ -596,7 +598,7 @@ describe('Route Handlers - Readonly Overview', () => {
         prisonerNumber: 'A12345B',
         prisonId: 'MDI',
       } as Prisoner)
-      prisonerService.hasActiveSentences.mockResolvedValue(false)
+      prisonerService.hasActiveSentencesAsSystem.mockResolvedValue(false)
       remandAndSentencingService.searchCourtCases.mockResolvedValue({
         content: [
           {
@@ -637,7 +639,7 @@ describe('Route Handlers - Readonly Overview', () => {
         prisonerNumber: 'A12345B',
         prisonId: 'MDI',
       } as Prisoner)
-      prisonerService.hasActiveSentences.mockResolvedValue(false)
+      prisonerService.hasActiveSentencesAsSystem.mockResolvedValue(false)
 
       const res = await request(app).get('/prisoner/A12345B/readonly-overview').expect(200)
 
@@ -656,7 +658,7 @@ describe('Route Handlers - Readonly Overview', () => {
         prisonerNumber: 'A12345B',
         prisonId: 'MDI',
       } as Prisoner)
-      prisonerService.hasActiveSentences.mockResolvedValue(false)
+      prisonerService.hasActiveSentencesAsSystem.mockResolvedValue(false)
       remandAndSentencingService.getLatestImmigrationDetentionRecordForPrisoner.mockResolvedValue(undefined)
       immigrationDetentionService.getImmigrationDetentionMessage.mockReturnValue(
         'There are no immigration documents recorded.',
@@ -684,7 +686,7 @@ describe('Route Handlers - Readonly Overview', () => {
         prisonerNumber: 'A12345B',
         prisonId: 'MDI',
       } as Prisoner)
-      prisonerService.hasActiveSentences.mockResolvedValue(false)
+      prisonerService.hasActiveSentencesAsSystem.mockResolvedValue(false)
       remandAndSentencingService.getLatestImmigrationDetentionRecordForPrisoner.mockResolvedValue(
         immigrationDetentionRecord,
       )
@@ -707,8 +709,8 @@ describe('Route Handlers - Readonly Overview', () => {
         prisonerNumber: 'A12345B',
         prisonId: 'MDI',
       } as Prisoner)
-      prisonerService.hasActiveSentences.mockResolvedValue(false)
-      remandAndSentencingService.getMostRecentRecall.mockResolvedValue({
+      prisonerService.hasActiveSentencesAsSystem.mockResolvedValue(false)
+      remandAndSentencingService.getMostRecentRecallAsSystem.mockResolvedValue({
         source: 'DPS',
         createdAt: '2024-01-01',
         recallType: RecallTypes.STANDARD_RECALL,
@@ -730,8 +732,8 @@ describe('Route Handlers - Readonly Overview', () => {
         prisonerNumber: 'A12345B',
         prisonId: 'MDI',
       } as Prisoner)
-      prisonerService.hasActiveSentences.mockResolvedValue(false)
-      remandAndSentencingService.getMostRecentRecall.mockResolvedValue(undefined)
+      prisonerService.hasActiveSentencesAsSystem.mockResolvedValue(false)
+      remandAndSentencingService.getMostRecentRecallAsSystem.mockResolvedValue(undefined)
 
       const res = await request(app).get('/prisoner/A12345B/readonly-overview').expect(200)
 
@@ -745,8 +747,8 @@ describe('Route Handlers - Readonly Overview', () => {
         prisonerNumber: 'A12345B',
         prisonId: 'MDI',
       } as Prisoner)
-      prisonerService.hasActiveSentences.mockResolvedValue(false)
-      remandAndSentencingService.getMostRecentRecall.mockResolvedValue({
+      prisonerService.hasActiveSentencesAsSystem.mockResolvedValue(false)
+      remandAndSentencingService.getMostRecentRecallAsSystem.mockResolvedValue({
         source: 'DPS',
         createdAt: '2024-01-01',
         recallType: RecallTypes.STANDARD_RECALL,
@@ -768,8 +770,8 @@ describe('Route Handlers - Readonly Overview', () => {
         prisonerNumber: 'A12345B',
         prisonId: 'MDI',
       } as Prisoner)
-      prisonerService.hasActiveSentences.mockResolvedValue(false)
-      remandAndSentencingService.getMostRecentRecall.mockResolvedValue({
+      prisonerService.hasActiveSentencesAsSystem.mockResolvedValue(false)
+      remandAndSentencingService.getMostRecentRecallAsSystem.mockResolvedValue({
         source: 'NOMIS',
         createdAt: '2024-01-01',
         recallType: RecallTypes.STANDARD_RECALL,
@@ -790,8 +792,8 @@ describe('Route Handlers - Readonly Overview', () => {
         prisonerNumber: 'A12345B',
         prisonId: 'MDI',
       } as Prisoner)
-      prisonerService.hasActiveSentences.mockResolvedValue(false)
-      remandAndSentencingService.getMostRecentRecall.mockResolvedValue({
+      prisonerService.hasActiveSentencesAsSystem.mockResolvedValue(false)
+      remandAndSentencingService.getMostRecentRecallAsSystem.mockResolvedValue({
         source: 'DPS',
         createdAt: '2024-01-01',
         recallType: RecallTypes.STANDARD_RECALL,
@@ -813,8 +815,8 @@ describe('Route Handlers - Readonly Overview', () => {
         prisonerNumber: 'A12345B',
         prisonId: 'MDI',
       } as Prisoner)
-      prisonerService.hasActiveSentences.mockResolvedValue(false)
-      prisonerService.getNextCourtEvent.mockResolvedValue({} as CourtEventDetails)
+      prisonerService.hasActiveSentencesAsSystem.mockResolvedValue(false)
+      prisonerService.getNextCourtEventAsSystem.mockResolvedValue({} as CourtEventDetails)
 
       const res = await request(app).get('/prisoner/A12345B/readonly-overview').expect(200)
 
@@ -826,8 +828,8 @@ describe('Route Handlers - Readonly Overview', () => {
         prisonerNumber: 'A12345B',
         prisonId: 'MDI',
       } as Prisoner)
-      prisonerService.hasActiveSentences.mockResolvedValue(false)
-      prisonerService.getNextCourtEvent.mockResolvedValue({
+      prisonerService.hasActiveSentencesAsSystem.mockResolvedValue(false)
+      prisonerService.getNextCourtEventAsSystem.mockResolvedValue({
         caseReference: 'CASE-123',
         courtLocation: 'Leeds Crown Court',
         courtEventType: 'Sentencing',
@@ -861,8 +863,8 @@ describe('Route Handlers - Readonly Overview', () => {
         prisonId: 'OUT',
       } as Prisoner)
       prisonerService.getStartOfSentenceEnvelope.mockResolvedValue(new Date())
-      prisonerService.getNextCourtEvent.mockResolvedValue({} as CourtEventDetails)
-      prisonerService.hasActiveSentences.mockResolvedValue(false)
+      prisonerService.getNextCourtEventAsSystem.mockResolvedValue({} as CourtEventDetails)
+      prisonerService.hasActiveSentencesAsSystem.mockResolvedValue(false)
       prisonerService.getServiceDefinitions.mockResolvedValue(serviceDefinitionsNoThingsToDo)
 
       return request(app)

--- a/server/routes/prisoner/handlers/readonlyOverview.ts
+++ b/server/routes/prisoner/handlers/readonlyOverview.ts
@@ -25,7 +25,7 @@ export default class ReadonlyOverviewRoutes {
 
   GET = async (req: Request, res: Response): Promise<void> => {
     const { prisoner } = req
-    const { token, username, hasImmigrationDetentionAccess } = res.locals.user
+    const { username, hasImmigrationDetentionAccess } = res.locals.user
     const bookingId = prisoner.bookingId as unknown as number
 
     const latestImmigrationRecordPromise: Promise<ImmigrationDetention | undefined> = hasImmigrationDetentionAccess
@@ -42,15 +42,17 @@ export default class ReadonlyOverviewRoutes {
       latestImmigrationRecord,
       [courtCaseDetailModels, offenceMap, offenceOutcomeMap],
     ] = await Promise.all([
-      this.prisonerService.hasActiveSentences(bookingId, token),
-      this.prisonerService.getNextCourtEvent(bookingId, token),
-      this.remandAndSentencingService.getMostRecentRecall(prisoner.prisonerNumber, token),
+      this.prisonerService.hasActiveSentencesAsSystem(bookingId, username),
+      this.prisonerService.getNextCourtEventAsSystem(bookingId, username),
+      this.remandAndSentencingService.getMostRecentRecallAsSystem(prisoner.prisonerNumber, username),
       latestImmigrationRecordPromise,
       this.getCourtCases(req, prisoner, username),
     ])
-
     const latestCalculationConfig = hasActiveSentences
-      ? await this.calculateReleaseDatesService.getLatestCalculationForPrisoner(prisoner.prisonerNumber, token)
+      ? await this.calculateReleaseDatesService.getLatestCalculationForPrisonerAsSystem(
+          prisoner.prisonerNumber,
+          username,
+        )
       : null
 
     const feedbackPrompt: ThingToDo = {

--- a/server/services/calculateReleaseDatesService.test.ts
+++ b/server/services/calculateReleaseDatesService.test.ts
@@ -3,6 +3,7 @@ import nock from 'nock'
 import { LatestCalculation } from '../@types/calculateReleaseDatesApi/types'
 import CalculateReleaseDatesService from './calculateReleaseDatesService'
 import config from '../config'
+import { HmppsAuthClient } from '../data'
 
 const prisonerId = 'A1234AB'
 
@@ -12,7 +13,8 @@ describe('Calculate release dates service', () => {
   beforeEach(() => {
     config.apis.calculateReleaseDatesApi.url = 'http://localhost:8100'
     fakeApi = nock(config.apis.calculateReleaseDatesApi.url)
-    calculateReleaseDatesService = new CalculateReleaseDatesService()
+    const hmppsAuthClient = {} as jest.Mocked<HmppsAuthClient>
+    calculateReleaseDatesService = new CalculateReleaseDatesService(hmppsAuthClient)
   })
   afterEach(() => {
     nock.cleanAll()

--- a/server/services/calculateReleaseDatesService.ts
+++ b/server/services/calculateReleaseDatesService.ts
@@ -6,8 +6,18 @@ import {
 import { LatestCalculation } from '../@types/calculateReleaseDatesApi/types'
 import CalculateReleaseDatesApiClient from '../data/calculateReleaseDatesApiClient'
 import logger from '../../logger'
+import { HmppsAuthClient } from '../data'
 
 export default class CalculateReleaseDatesService {
+  constructor(private readonly hmppsAuthClient: HmppsAuthClient) {}
+
+  async getLatestCalculationForPrisonerAsSystem(
+    prisonerNumber: string,
+    username: string,
+  ): Promise<LatestCalculationCardConfig> {
+    return this.getLatestCalculationForPrisoner(prisonerNumber, await this.getSystemClientToken(username))
+  }
+
   async getLatestCalculationForPrisoner(prisonerNumber: string, token: string): Promise<LatestCalculationCardConfig> {
     try {
       const latestCalculation = await new CalculateReleaseDatesApiClient(token).getLatestCalculationForPrisoner(
@@ -22,6 +32,10 @@ export default class CalculateReleaseDatesService {
 
   async hasIndeterminateSentences(bookingId: number, token: string): Promise<boolean> {
     return new CalculateReleaseDatesApiClient(token).hasIndeterminateSentences(bookingId)
+  }
+
+  private async getSystemClientToken(username: string): Promise<string> {
+    return this.hmppsAuthClient.getSystemClientToken(username)
   }
 
   private latestCalculationComponentConfig(latestCalculation: LatestCalculation): LatestCalculationCardConfig {

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -28,7 +28,7 @@ export const services = () => {
 
   const adjustmentsService = new AdjustmentsService(hmppsAuthClient)
 
-  const calculateReleaseDatesService = new CalculateReleaseDatesService()
+  const calculateReleaseDatesService = new CalculateReleaseDatesService(hmppsAuthClient)
 
   const remandAndSentencingService = new RemandAndSentencingService(hmppsAuthClient)
 

--- a/server/services/prisonerService.ts
+++ b/server/services/prisonerService.ts
@@ -18,6 +18,10 @@ export default class PrisonerService {
     return new PrisonApiClient(await this.getSystemClientToken(username)).getPrisonerImage(prisonerNumber)
   }
 
+  async getNextCourtEventAsSystem(bookingId: number, username: string): Promise<CourtEventDetails> {
+    return this.getNextCourtEvent(bookingId, await this.getSystemClientToken(username))
+  }
+
   async getNextCourtEvent(bookingId: number, token: string): Promise<CourtEventDetails> {
     return new PrisonApiClient(token).getNextCourtEvent(bookingId)
   }
@@ -46,6 +50,10 @@ export default class PrisonerService {
       )
     }
     return null
+  }
+
+  async hasActiveSentencesAsSystem(bookingId: number, username: string): Promise<boolean> {
+    return this.hasActiveSentences(bookingId, await this.getSystemClientToken(username))
   }
 
   async hasActiveSentences(bookingId: number, token: string): Promise<boolean> {

--- a/server/services/remandAndSentencingService.ts
+++ b/server/services/remandAndSentencingService.ts
@@ -38,6 +38,10 @@ export default class RemandAndSentencingService {
     return this.hmppsAuthClient.getSystemClientToken(username)
   }
 
+  async getMostRecentRecallAsSystem(nomsId: string, username: string): Promise<Recall> {
+    return this.getMostRecentRecall(nomsId, await this.getSystemClientToken(username))
+  }
+
   async getMostRecentRecall(nomsId: string, token: string): Promise<Recall> {
     const client = new RemandAndSentencingApiClient(token)
     const allApiRecalls = await client.getAllRecalls(nomsId)


### PR DESCRIPTION
Adjusting readonly-overview permissions to delegate endpoint calls to client_credentials and adding url exclusion