### PR TITLE
RASS-2466 Refactor to use permissions lib instead of direct roles check

### DIFF
--- a/integration_tests/mockApis/auth.ts
+++ b/integration_tests/mockApis/auth.ts
@@ -113,6 +113,7 @@ const token = (roles: string[] = ['ROLE_RELEASE_DATES_CALCULATOR']) =>
         access_token: createToken(roles),
         token_type: 'bearer',
         user_name: 'USER1',
+        auth_source: 'nomis',
         expires_in: 599,
         scope: 'read',
         internalUser: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@ministryofjustice/hmpps-audit-client": "^1.1.3",
         "@ministryofjustice/hmpps-auth-clients": "^1.0.2",
         "@ministryofjustice/hmpps-court-cases-release-dates-design": "^5.2.2",
+        "@ministryofjustice/hmpps-prison-permissions-lib": "4.2.0",
         "@ministryofjustice/hmpps-rest-client": "^2.2.0",
         "@types/lodash": "^4.17.24",
         "agentkeepalive": "^4.6.0",
@@ -3068,6 +3069,18 @@
         "hmpps-precommit-hooks": "bin/init.sh",
         "hmpps-precommit-hooks-prepare": "bin/prepare.sh",
         "test-secret-protection": "bin/test.sh"
+      },
+      "engines": {
+        "node": "22 || 24 || 26"
+      }
+    },
+    "node_modules/@ministryofjustice/hmpps-prison-permissions-lib": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/hmpps-prison-permissions-lib/-/hmpps-prison-permissions-lib-4.2.0.tgz",
+      "integrity": "sha512-xN1QGfHOBx96V1adC5tqgKG7vr/Mp7HIhFNQ6jIR3rgJFU42yASBPQEWq9TSYgZ6CD06CnvHfw6zRRn7X7rlww==",
+      "license": "MIT",
+      "dependencies": {
+        "@ministryofjustice/hmpps-rest-client": "2.2.0"
       },
       "engines": {
         "node": "22 || 24 || 26"

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@ministryofjustice/hmpps-audit-client": "^1.1.3",
     "@ministryofjustice/hmpps-auth-clients": "^1.0.2",
     "@ministryofjustice/hmpps-court-cases-release-dates-design": "^5.2.2",
+    "@ministryofjustice/hmpps-prison-permissions-lib": "4.2.0",
     "@ministryofjustice/hmpps-rest-client": "^2.2.0",
     "@types/lodash": "^4.17.24",
     "agentkeepalive": "^4.6.0",

--- a/server/app.ts
+++ b/server/app.ts
@@ -38,7 +38,7 @@ export default function createApp(services: Services): express.Application {
   app.use(setUpStaticResources())
   nunjucksSetup(app, services.applicationInfo)
   app.use(setUpAuthentication())
-  app.use(authorisationMiddleware(['ROLE_RELEASE_DATES_CALCULATOR'], ['^/prisoner/[^/]+/readonly-overview$']))
+  app.use(authorisationMiddleware())
   app.use(setUpCsrf())
   app.use(setUpCurrentUser(services))
 

--- a/server/app.ts
+++ b/server/app.ts
@@ -39,6 +39,7 @@ export default function createApp(services: Services): express.Application {
   nunjucksSetup(app, services.applicationInfo)
   app.use(setUpAuthentication())
   app.use(authorisationMiddleware())
+  app.use(['/config', '/unmatched-documents'], authorisationMiddleware(['ROLE_RELEASE_DATES_CALCULATOR']))
   app.use(setUpCsrf())
   app.use(setUpCurrentUser(services))
 

--- a/server/middleware/authorisationMiddleware.test.ts
+++ b/server/middleware/authorisationMiddleware.test.ts
@@ -53,36 +53,6 @@ describe('authorisationMiddleware', () => {
     expect(res.redirect).toHaveBeenCalledWith('/authError')
   })
 
-  it('should return next when user has no authorised roles but accesses excluded path', () => {
-    const res = createResWithToken({ authorities: [] })
-
-    const reqWithPath = { path: '/prisoner/ABC123/readonly-overview' } as Request
-    authorisationMiddleware(['NON_RELEVANT_ROLE'], ['^/prisoner/[^/]+/readonly-overview$'])(reqWithPath, res, next)
-
-    expect(next).toHaveBeenCalled()
-    expect(res.redirect).not.toHaveBeenCalled()
-  })
-
-  it('should redirect when user has no authorised roles and accesses a non excluded path', () => {
-    const res = createResWithToken({ authorities: [] })
-
-    const reqWithPath = { path: '/prisoner/ABC123/overview' } as Request
-    authorisationMiddleware(['NON_RELEVANT_ROLE'], ['^/prisoner/[^/]+/readonly-overview$'])(reqWithPath, res, next)
-
-    expect(next).not.toHaveBeenCalled()
-    expect(res.redirect).toHaveBeenCalledWith('/authError')
-  })
-
-  it('should redirect when user has no authorised roles and accesses a path with no exclusions specified', () => {
-    const res = createResWithToken({ authorities: [] })
-
-    const reqWithPath = { path: '/' } as Request
-    authorisationMiddleware(['NON_RELEVANT_ROLE'], [])(reqWithPath, res, next)
-
-    expect(next).not.toHaveBeenCalled()
-    expect(res.redirect).toHaveBeenCalledWith('/authError')
-  })
-
   it('should return next when user has authorised role', () => {
     const res = createResWithToken({ authorities: ['ROLE_SOME_REQUIRED_ROLE'] })
 

--- a/server/middleware/authorisationMiddleware.ts
+++ b/server/middleware/authorisationMiddleware.ts
@@ -4,18 +4,8 @@ import type { RequestHandler } from 'express'
 import logger from '../../logger'
 import asyncMiddleware from './asyncMiddleware'
 
-export default function authorisationMiddleware(
-  authorisedRoles: string[] = [],
-  excludedPaths: string[] = [],
-): RequestHandler {
-  const excludedPathRegExps = excludedPaths.map(p => new RegExp(p))
-
+export default function authorisationMiddleware(authorisedRoles: string[] = []): RequestHandler {
   return asyncMiddleware((req, res, next) => {
-    // Skip authorisation for excluded paths
-    if (excludedPathRegExps.some(pattern => pattern.test(req.path))) {
-      return next()
-    }
-
     // authorities in the user token will always be prefixed by ROLE_.
     // Convert roles that are passed into this function without the prefix so that we match correctly.
     const authorisedAuthorities = authorisedRoles.map(role => (role.startsWith('ROLE_') ? role : `ROLE_${role}`))

--- a/server/middleware/getPrisoner.ts
+++ b/server/middleware/getPrisoner.ts
@@ -12,7 +12,7 @@ export default function getPrisoner(prisonerSearchService: PrisonerSearchService
       try {
         const prisoner = await prisonerSearchService.getByPrisonerNumber(res.locals.user.username, prisonerNumber)
         req.prisoner = prisoner
-        const isInCaseload = user.caseloads.includes(prisoner.prisonId)
+        const isInCaseload = user.caseLoads?.some(caseLoad => caseLoad.caseLoadId === prisoner.prisonId)
         const isPrisonerOutside = prisoner.prisonId === 'OUT'
         const isPrisonerBeingTransferred = prisoner.prisonId === 'TRN'
         if (!isInCaseload && !(user.hasInactiveBookingAccess && (isPrisonerOutside || isPrisonerBeingTransferred))) {

--- a/server/routes/prisoner/index.ts
+++ b/server/routes/prisoner/index.ts
@@ -1,4 +1,8 @@
 import { RequestHandler, Router } from 'express'
+import {
+  PersonSentenceCalculationPermission,
+  prisonerPermissionsGuard,
+} from '@ministryofjustice/hmpps-prison-permissions-lib'
 import { Services } from '../../services'
 import asyncMiddleware from '../../middleware/asyncMiddleware'
 import AdjustmentsRoutes from './handlers/adjustments'
@@ -21,17 +25,27 @@ export default function Index({
   courtRegisterService,
   manageOffencesService,
   immigrationDetentionService,
+  prisonPermissionsService,
 }: Services): Router {
   const router = Router()
-  const get = (path: string | string[], handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
-  const post = (path: string | string[], handler: RequestHandler) => router.post(path, asyncMiddleware(handler))
+  const get = (path: string | string[], ...handlers: RequestHandler[]) =>
+    router.get(path, ...handlers.map(handler => asyncMiddleware(handler)))
+  const post = (path: string | string[], ...handlers: RequestHandler[]) =>
+    router.post(path, ...handlers.map(handler => asyncMiddleware(handler)))
 
-  router.get('/:prisonerNumber/image', new ImageRoutes(prisonerService).GET)
+  const requireRead = prisonerPermissionsGuard(prisonPermissionsService, {
+    requestDependentOn: [PersonSentenceCalculationPermission.read],
+  })
+  const requireEdit = prisonerPermissionsGuard(prisonPermissionsService, {
+    requestDependentOn: [PersonSentenceCalculationPermission.edit],
+  })
 
-  get('/:prisonerNumber/adjustments', new AdjustmentsRoutes().GET)
-  get('/:prisonerNumber/court-cases', new CourtCasesRoutes().GET)
+  get('/:prisonerNumber/image', requireEdit, new ImageRoutes(prisonerService).GET)
+  get('/:prisonerNumber/adjustments', requireEdit, new AdjustmentsRoutes().GET)
+  get('/:prisonerNumber/court-cases', requireEdit, new CourtCasesRoutes().GET)
   get(
     '/:prisonerNumber/overview',
+    requireEdit,
     new OverviewRoutes(
       prisonerService,
       adjustmentsService,
@@ -43,6 +57,7 @@ export default function Index({
   )
   get(
     '/:prisonerNumber/readonly-overview',
+    requireRead,
     new ReadonlyOverviewRoutes(
       prisonerService,
       calculateReleaseDatesService,
@@ -52,10 +67,11 @@ export default function Index({
       immigrationDetentionService,
     ).GET,
   )
-  get('/:prisonerNumber/release-dates', new ReleaseDatesRoutes().GET)
+  get('/:prisonerNumber/release-dates', requireEdit, new ReleaseDatesRoutes().GET)
 
   get(
     '/:prisonerNumber/documents',
+    requireEdit,
     new DocumentRoutes(
       prisonerService,
       documentManagementService,
@@ -66,6 +82,7 @@ export default function Index({
   )
   get(
     ['/:prisonerNumber/documents/:documentId/download/:filename', '/:prisonerNumber/documents/:documentId/download'],
+    requireEdit,
     new DocumentRoutes(
       prisonerService,
       documentManagementService,
@@ -77,6 +94,7 @@ export default function Index({
 
   post(
     '/:prisonerNumber/documents/:documentId/mark-as-new',
+    requireEdit,
     new DocumentRoutes(
       prisonerService,
       documentManagementService,

--- a/server/routes/prisoner/index.ts
+++ b/server/routes/prisoner/index.ts
@@ -40,7 +40,7 @@ export default function Index({
     requestDependentOn: [PersonSentenceCalculationPermission.edit],
   })
 
-  get('/:prisonerNumber/image', requireEdit, new ImageRoutes(prisonerService).GET)
+  get('/:prisonerNumber/image', requireRead, new ImageRoutes(prisonerService).GET)
   get('/:prisonerNumber/adjustments', requireEdit, new AdjustmentsRoutes().GET)
   get('/:prisonerNumber/court-cases', requireEdit, new CourtCasesRoutes().GET)
   get(

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -1,6 +1,7 @@
 import express, { Express } from 'express'
 import cookieSession from 'cookie-session'
 import { NotFound } from 'http-errors'
+import { PermissionsService, PersonSentenceCalculationPermission } from '@ministryofjustice/hmpps-prison-permissions-lib'
 
 import routes from '../index'
 import nunjucksSetup from '../../utils/nunjucksSetup'
@@ -30,10 +31,26 @@ export const user: Express.User = {
   activeCaseLoadId: 'MDI',
   authSource: 'NOMIS',
   caseloads: ['MDI'],
+  caseLoads: [{ caseLoadId: 'MDI' }],
   roles: [],
+  userRoles: [],
 }
 
 export const flashProvider = jest.fn()
+
+const prisonPermissionsService = {
+  getPrisonerPermissions: () => ({
+    domainGroups: {
+      sentenceAndOffence: {
+        personSentenceCalculation: {
+          [PersonSentenceCalculationPermission.read]: true,
+          [PersonSentenceCalculationPermission.edit]: true,
+        },
+      },
+    },
+  }),
+  getPrisonerDetails: async () => ({ prisonerNumber: 'A1234AA', prisonId: 'MDI' }),
+} as unknown as PermissionsService
 
 function appSetup(services: Services, production: boolean, userSupplier: () => Express.User): Express {
   const app = express()
@@ -76,5 +93,5 @@ export function appWithAllRoutes({
   userSupplier?: () => Express.User
 }): Express {
   auth.default.authenticationMiddleware = () => (req, res, next) => next()
-  return appSetup(services as Services, production, userSupplier)
+  return appSetup({ prisonPermissionsService, ...services } as Services, production, userSupplier)
 }

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -33,8 +33,7 @@ export const user: Express.User = {
   active: true,
   activeCaseLoadId: 'MDI',
   authSource: 'NOMIS',
-  caseloads: ['MDI'],
-  caseLoads: [{ caseLoadId: 'MDI' }],
+  caseLoads: [{ caseLoadId: 'MDI', description: 'Moorland', type: 'INST', currentlyActive: true }],
   roles: [],
   userRoles: [],
 }

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -1,7 +1,10 @@
 import express, { Express } from 'express'
 import cookieSession from 'cookie-session'
 import { NotFound } from 'http-errors'
-import { PermissionsService, PersonSentenceCalculationPermission } from '@ministryofjustice/hmpps-prison-permissions-lib'
+import {
+  PermissionsService,
+  PersonSentenceCalculationPermission,
+} from '@ministryofjustice/hmpps-prison-permissions-lib'
 
 import routes from '../index'
 import nunjucksSetup from '../../utils/nunjucksSetup'

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -1,3 +1,4 @@
+import { PermissionsService } from '@ministryofjustice/hmpps-prison-permissions-lib'
 import { dataAccess } from '../data'
 import UserService from './userService'
 import FeComponentsService from './feComponentsService'
@@ -13,6 +14,8 @@ import CourtRegisterService from './courtRegisterService'
 import ManageOffencesService from './manageOffencesService'
 import ManageOffencesApiClient from '../data/manageOffencesApiClient'
 import ImmigrationDetentionService from './ImmigrationDetentionService'
+import config from '../config'
+import logger from '../../logger'
 
 export const services = () => {
   const { applicationInfo, hmppsAuthClient, hmppsAuthenticationClient, manageUsersApiClient, feComponentsClient } =
@@ -44,6 +47,12 @@ export const services = () => {
 
   const immigrationDetentionService = new ImmigrationDetentionService()
 
+  const prisonPermissionsService = PermissionsService.create({
+    prisonerSearchConfig: config.apis.prisonerSearchApi,
+    authenticationClient: hmppsAuthenticationClient,
+    logger,
+  })
+
   return {
     applicationInfo,
     userService,
@@ -59,6 +68,7 @@ export const services = () => {
     courtRegisterService,
     manageOffencesService,
     immigrationDetentionService,
+    prisonPermissionsService,
   }
 }
 

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -3,6 +3,7 @@ import { convertToTitleCase } from '../utils/utils'
 import type { User } from '../data/manageUsersApiClient'
 import ManageUsersApiClient from '../data/manageUsersApiClient'
 import PrisonerService from './prisonerService'
+import { PrisonApiUserCaseloads } from '../@types/prisonApi/types'
 
 export interface UserDetails extends User {
   displayName: string
@@ -13,8 +14,7 @@ export interface UserDetails extends User {
   hasInactiveBookingAccess: boolean
   hasReadOnlyNomisConfigAccess: boolean
   hasImmigrationDetentionAccess: boolean
-  caseloads: string[]
-  caseLoads: { caseLoadId: string }[]
+  caseLoads: PrisonApiUserCaseloads[]
   caseloadDescriptions: string[]
   caseloadMap: Map<string, string>
 }
@@ -41,7 +41,6 @@ export default class UserService {
       hasInactiveBookingAccess: this.hasInactiveBookingAccess(roles),
       hasReadOnlyNomisConfigAccess: this.hasReadOnlyNomisConfigAccess(roles),
       hasImmigrationDetentionAccess: this.hasImmigrationDetentionAccess(roles),
-      caseloads: userCaseloads.map(uc => uc.caseLoadId),
       caseLoads: userCaseloads,
       caseloadDescriptions: userCaseloads.map(uc => uc.description),
       caseloadMap: new Map(userCaseloads.map(uc => [uc.caseLoadId, uc.description])),

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -7,12 +7,14 @@ import PrisonerService from './prisonerService'
 export interface UserDetails extends User {
   displayName: string
   roles: string[]
+  userRoles: string[]
   hasRasAccess: boolean
   hasRecallsAccess: boolean
   hasInactiveBookingAccess: boolean
   hasReadOnlyNomisConfigAccess: boolean
   hasImmigrationDetentionAccess: boolean
   caseloads: string[]
+  caseLoads: { caseLoadId: string }[]
   caseloadDescriptions: string[]
   caseloadMap: Map<string, string>
 }
@@ -32,6 +34,7 @@ export default class UserService {
     return {
       ...user,
       roles,
+      userRoles: roles.map(role => `ROLE_${role}`),
       displayName: convertToTitleCase(user.name),
       hasRasAccess: this.hasRasAccess(roles),
       hasRecallsAccess: this.hasRecallAccess(roles),
@@ -39,6 +42,7 @@ export default class UserService {
       hasReadOnlyNomisConfigAccess: this.hasReadOnlyNomisConfigAccess(roles),
       hasImmigrationDetentionAccess: this.hasImmigrationDetentionAccess(roles),
       caseloads: userCaseloads.map(uc => uc.caseLoadId),
+      caseLoads: userCaseloads,
       caseloadDescriptions: userCaseloads.map(uc => uc.description),
       caseloadMap: new Map(userCaseloads.map(uc => [uc.caseLoadId, uc.description])),
     }


### PR DESCRIPTION
We made this change under advice from the DPS connect team

The _permissions library_ is a place where cross service pesmissions are consolidated, therefore can be changed in one place.

So rather than explicitly checking roles (etc) here - the check is done in the permissions lib and we protect our routes with the appropriate permission.

The `PersonSentenceCalculationPermission.read` is basically any authenticated user
The `PersonSentenceCalculationPermission.edit` is any user with role  RELEASE_DATES_CALCULATOR