### PR TITLE
Wire-in the TelemetryClient to PermissionsService

### DIFF
--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -4,12 +4,20 @@
  * In particular, applicationinsights automatically collects bunyan logs
  */
 import { AuthenticationClient } from '@ministryofjustice/hmpps-auth-clients'
-import { initialiseAppInsights, buildAppInsightsClient } from '../utils/azureAppInsights'
+import type { TelemetryClient } from 'applicationinsights'
+import type { TelemetryClient as PermissionsTelemetryClient } from '@ministryofjustice/hmpps-prison-permissions-lib'
+import {
+  initialiseAppInsights,
+  buildAppInsightsClient,
+  buildPermissionsTelemetryClient,
+} from '../utils/azureAppInsights'
 import applicationInfoSupplier from '../applicationInfo'
 
 const applicationInfo = applicationInfoSupplier()
 initialiseAppInsights()
-buildAppInsightsClient(applicationInfo)
+const telemetryClient: TelemetryClient = buildAppInsightsClient(applicationInfo)
+export const telemetryClientPermissionsLibWrapper: PermissionsTelemetryClient =
+  buildPermissionsTelemetryClient(telemetryClient)
 
 import HmppsAuthClient from './hmppsAuthClient'
 import ManageUsersApiClient from './manageUsersApiClient'

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -1,5 +1,5 @@
 import { PermissionsService } from '@ministryofjustice/hmpps-prison-permissions-lib'
-import { dataAccess } from '../data'
+import { dataAccess, telemetryClientPermissionsLibWrapper } from '../data'
 import UserService from './userService'
 import FeComponentsService from './feComponentsService'
 import PrisonerSearchService from './prisonerSearchService'
@@ -51,6 +51,7 @@ export const services = () => {
     prisonerSearchConfig: config.apis.prisonerSearchApi,
     authenticationClient: hmppsAuthenticationClient,
     logger,
+    telemetryClient: telemetryClientPermissionsLibWrapper,
   })
 
   return {

--- a/server/utils/azureAppInsights.test.ts
+++ b/server/utils/azureAppInsights.test.ts
@@ -1,5 +1,5 @@
 import { DataTelemetry, EnvelopeTelemetry } from 'applicationinsights/out/Declarations/Contracts'
-import { addCustomDataToRequests, ContextObject } from './azureAppInsights'
+import { addCustomDataToRequests, ContextObject, buildPermissionsTelemetryClient } from './azureAppInsights'
 
 const user = {
   username: 'test-user',
@@ -76,6 +76,24 @@ describe('azureAppInsights', () => {
 
       expect(envelope.data.baseData.properties).toEqual({
         other: 'things',
+      })
+    })
+  })
+
+  describe('buildPermissionsTelemetryClient', () => {
+    it('returns undefined when no App Insights client is provided', () => {
+      expect(buildPermissionsTelemetryClient(null)).toBeUndefined()
+    })
+
+    it('Should wrap the trackEvent to the PermissionsTelemetryClient', () => {
+      const trackEvent = jest.fn()
+      const wrapper = buildPermissionsTelemetryClient({ trackEvent } as never)
+
+      wrapper.trackEvent('prisoner-permission-denied', { username: user.username, status: 'DENIED' })
+
+      expect(trackEvent).toHaveBeenCalledWith({
+        name: 'prisoner-permission-denied',
+        properties: { username: user.username, status: 'DENIED' },
       })
     })
   })

--- a/server/utils/azureAppInsights.ts
+++ b/server/utils/azureAppInsights.ts
@@ -1,6 +1,17 @@
 import { Contracts, setup, defaultClient, TelemetryClient, DistributedTracingModes } from 'applicationinsights'
 import { EnvelopeTelemetry } from 'applicationinsights/out/Declarations/Contracts'
+import type { TelemetryClient as PermissionsTelemetryClient } from '@ministryofjustice/hmpps-prison-permissions-lib'
 import type { ApplicationInfo } from '../applicationInfo'
+
+export function buildPermissionsTelemetryClient(client: TelemetryClient): PermissionsTelemetryClient | undefined {
+  if (!client) {
+    return undefined
+  }
+
+  return {
+    trackEvent: (name, properties) => client.trackEvent({ name, properties }),
+  }
+}
 
 export type ContextObject = {
   /* eslint-disable  @typescript-eslint/no-explicit-any */


### PR DESCRIPTION
Ensures the PermissionsLogger uses telementryClient#trackEvent rather than logger#info